### PR TITLE
Update performance  benchmark scripts

### DIFF
--- a/examples/perf_benchmark/batch_benchmark.py
+++ b/examples/perf_benchmark/batch_benchmark.py
@@ -1,0 +1,222 @@
+from benchmark import BenchmarkArgs
+from benchmark_plotter import plot_batch_benchmark
+import argparse
+import subprocess
+import os
+from datetime import datetime
+import pandas as pd
+
+class BatchBenchmarkArgs:
+    def __init__(self, use_full_list, continue_from):
+        self.use_full_list = use_full_list
+        self.continue_from = continue_from
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--use_full_list", action="store_true", default=False)
+    parser.add_argument("-c", "--continue_from", type=str, default=None)
+    args = parser.parse_args()
+    return BatchBenchmarkArgs(use_full_list=args.use_full_list, continue_from=args.continue_from)
+
+def create_batch_args(benchmark_result_file_path, use_full_list=False):
+    # Ensure the directory exists
+    os.makedirs(os.path.dirname(benchmark_result_file_path), exist_ok=True)
+    
+    # Create a list of all the possible combinations of arguments
+    # and return them as a list of BenchmarkArgs
+    full_mjcf_list = ["xml/franka_emika_panda/panda.xml", "xml/unitree_g1/g1.xml", "xml/unitree_go2/go2.xml"]
+    rasterizer_list = [True, False]
+    full_batch_size_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 12288, 16384]
+    square_resolution_list = [
+        (64, 64), (128, 128), (256, 256), (512, 512), (1024, 1024), (2048, 2048), (4096, 4096), (8192, 8192)
+    ]
+    four_three_resolution_list = [
+        (320, 240), (640, 480), (800, 600), (1024, 768), (1280, 960), (1600, 1200), (1920, 1440), (2048, 1536), (2560, 1920), (3200, 2400), (4096, 3072), (8192, 6144),
+    ]
+    sixteen_nine_resolution_list = [
+        (320, 180), (640, 360), (800, 450), (1024, 576), (1280, 720), (1600, 900), (1920, 1080), (2048, 1152), (2560, 1440), (3200, 1800), (4096, 2304), (8192, 4608),
+    ]
+    full_resolution_list = square_resolution_list + four_three_resolution_list + sixteen_nine_resolution_list
+
+    # Minimal mjcf, resolution, and batch size
+    minimal_mjcf_list = [
+        "xml/franka_emika_panda/panda.xml"
+    ]
+    minimal_batch_size_list = [
+        128, 256, 512, 1024
+    ]
+    minimal_resolution_list = [
+        (1024, 1024),
+        (2048, 2048),
+    ]
+
+    if use_full_list:
+        mjcf_list = full_mjcf_list
+        resolution_list = full_resolution_list
+        batch_size_list = full_batch_size_list
+    else:
+        mjcf_list = minimal_mjcf_list
+        resolution_list = minimal_resolution_list
+        batch_size_list = minimal_batch_size_list
+
+    # Batch data for resolution and batch size needs to be sorted in ascending order of resX x resY
+    # so that if one resolution fails, all the resolutions, which are larger, will be skipped.
+    resolution_list.sort(key=lambda x: x[0] * x[1])
+
+    # Hardcoded parameters
+    n_steps = 1
+    camera_pos = (1.5, 0.5, 1.5)
+    camera_lookat = (0.0, 0.0, 0.5)
+    camera_fov = 45
+
+    # Create a hierarchical dictionary to store all combinations
+    batch_args_dict = {}
+
+    # Build hierarchical structure
+    for rasterizer in rasterizer_list:
+        batch_args_dict[rasterizer] = {}
+        for mjcf in mjcf_list:
+            batch_args_dict[rasterizer][mjcf] = {}
+            for batch_size in batch_size_list:
+                batch_args_dict[rasterizer][mjcf][batch_size] = {}
+                for resolution in resolution_list:
+                    resX, resY = resolution
+                    # Create benchmark args for this combination
+                    args = BenchmarkArgs(
+                        rasterizer=rasterizer,
+                        n_envs=batch_size,
+                        n_steps=n_steps,
+                        resX=resX,
+                        resY=resY,
+                        camera_posX=camera_pos[0],
+                        camera_posY=camera_pos[1],
+                        camera_posZ=camera_pos[2],
+                        camera_lookatX=camera_lookat[0],
+                        camera_lookatY=camera_lookat[1],
+                        camera_lookatZ=camera_lookat[2],
+                        camera_fov=camera_fov,
+                        mjcf=mjcf,
+                        benchmark_result_file_path=benchmark_result_file_path
+                    )
+                    batch_args_dict[rasterizer][mjcf][batch_size][(resX,resY)] = args
+
+    return batch_args_dict
+
+def create_benchmark_result_file(continue_from_file_path):
+    if continue_from_file_path is not None:
+        if not os.path.exists(continue_from_file_path):
+            raise FileNotFoundError(f"Continue from file not found: {continue_from_file_path}")
+        print(f"Continuing from file: {continue_from_file_path}")
+        return continue_from_file_path
+    else:
+        # Create benchmark result data file with header
+        benchmark_data_directory = "logs/benchmark"
+        if not os.path.exists(benchmark_data_directory):
+            os.makedirs(benchmark_data_directory)
+        benchmark_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        benchmark_result_file_path = f"{benchmark_data_directory}/batch_benchmark_{benchmark_timestamp}.csv"
+        with open(benchmark_result_file_path, "w") as f:
+            f.write("result,mjcf,rasterizer,n_envs,n_steps,resX,resY,camera_posX,camera_posY,camera_posZ,camera_lookatX,camera_lookatY,camera_lookatZ,camera_fov,time_taken,time_taken_per_env,fps,fps_per_env\n")
+        print(f"Created new benchmark result file: {benchmark_result_file_path}")
+        return benchmark_result_file_path
+
+def get_previous_runs(continue_from_file_path):
+    if continue_from_file_path is None:
+        return []
+    
+    # Read the existing benchmark data file
+    df = pd.read_csv(continue_from_file_path)
+    
+    # Create a list of tuples containing run info and status
+    previous_runs = []
+    
+    for _, row in df.iterrows():
+        run_info = (
+            row['mjcf'],
+            row['rasterizer'],
+            row['n_envs'],
+            (row['resX'], row['resY']),
+            row['result']  # 'succeeded' or 'failed'
+        )
+        previous_runs.append(run_info)
+    
+    return previous_runs
+
+def run_batch_benchmark(batch_args_dict, benchmark_script_path, previous_runs=None):
+    if previous_runs is None:
+        previous_runs = []
+        
+    for rasterizer in batch_args_dict:
+        for mjcf in batch_args_dict[rasterizer]:
+            for batch_size in batch_args_dict[rasterizer][mjcf]:
+                last_resolution_failed = False
+                for resolution in batch_args_dict[rasterizer][mjcf][batch_size]:
+                    if last_resolution_failed:
+                        break
+                    
+                    # Check if this run was in a previous execution
+                    run_info = (mjcf, rasterizer, batch_size, resolution)
+                    skip_this_run = False
+                    
+                    for prev_run in previous_runs:
+                        if run_info == prev_run[:4]:  # Compare only the run parameters, not the status
+                            skip_this_run = True
+                            if prev_run[4] == 'failed':
+                                # Skip this and subsequent resolutions if it failed before
+                                last_resolution_failed = True
+                            break
+                    
+                    if skip_this_run:
+                        continue
+                        
+                    # Run the benchmark
+                    batch_args = batch_args_dict[rasterizer][mjcf][batch_size][resolution]
+                    
+                    # launch a process to run the benchmark
+                    cmd = ["python3", benchmark_script_path]
+                    if batch_args.rasterizer:
+                        cmd.append("-r")
+                    cmd.extend([
+                        "-n", str(batch_args.n_envs),
+                        "-s", str(batch_args.n_steps),
+                        "-x", str(batch_args.resX), 
+                        "-y", str(batch_args.resY),
+                        "-i", str(batch_args.camera_posX),
+                        "-j", str(batch_args.camera_posY),
+                        "-k", str(batch_args.camera_posZ), 
+                        "-l", str(batch_args.camera_lookatX),
+                        "-m", str(batch_args.camera_lookatY),
+                        "-o", str(batch_args.camera_lookatZ),
+                        "-v", str(batch_args.camera_fov),
+                        "-f", batch_args.mjcf,
+                        "-g", batch_args.benchmark_result_file_path
+                    ])
+                    process = subprocess.Popen(cmd)
+                    if process.wait() != 0:
+                        last_resolution_failed = True
+                        # Write failed result without timing data
+                        with open(batch_args.benchmark_result_file_path, 'a') as f:
+                            f.write(f'failed,{batch_args.mjcf},{batch_args.rasterizer},{batch_args.n_envs},{batch_args.n_steps},{batch_args.resX},{batch_args.resY},{batch_args.camera_posX},{batch_args.camera_posY},{batch_args.camera_posZ},{batch_args.camera_lookatX},{batch_args.camera_lookatY},{batch_args.camera_lookatZ},{batch_args.camera_fov},,,,\n')
+                        break
+
+def main():
+    batch_benchmark_args = parse_args()
+    benchmark_result_file_path = create_benchmark_result_file(batch_benchmark_args.continue_from)
+    
+    # Get list of previous runs if continuing from a previous run
+    previous_runs = get_previous_runs(batch_benchmark_args.continue_from)
+
+    # Run benchmark in batch
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    benchmark_script_path = f"{current_dir}/benchmark.py"
+    if not os.path.exists(benchmark_script_path):
+        raise FileNotFoundError(f"Benchmark script not found: {benchmark_script_path}")
+        
+    batch_args_dict = create_batch_args(benchmark_result_file_path, use_full_list=batch_benchmark_args.use_full_list)
+    run_batch_benchmark(batch_args_dict, benchmark_script_path, previous_runs)
+
+    # Generate plots
+    plot_batch_benchmark(benchmark_result_file_path)
+
+if __name__ == "__main__":
+    main()

--- a/examples/perf_benchmark/benchmark.py
+++ b/examples/perf_benchmark/benchmark.py
@@ -1,0 +1,180 @@
+import argparse
+import os
+
+import numpy as np
+import genesis as gs
+
+# Create a struct to store the arguments
+class BenchmarkArgs:
+    def __init__(self, rasterizer, n_envs, n_steps, resX, resY, camera_posX, camera_posY, camera_posZ, camera_lookatX, camera_lookatY, camera_lookatZ, camera_fov, mjcf, benchmark_result_file_path):
+        self.rasterizer = rasterizer
+        self.n_envs = n_envs
+        self.n_steps = n_steps
+        self.resX = resX
+        self.resY = resY
+        self.camera_posX = camera_posX
+        self.camera_posY = camera_posY
+        self.camera_posZ = camera_posZ
+        self.camera_lookatX = camera_lookatX
+        self.camera_lookatY = camera_lookatY
+        self.camera_lookatZ = camera_lookatZ
+        self.camera_fov = camera_fov
+        self.mjcf = mjcf
+        self.benchmark_result_file_path = benchmark_result_file_path
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--rasterizer", action="store_true", default=False)
+    parser.add_argument("-n", "--n_envs", type=int, default=1024)
+    parser.add_argument("-s", "--n_steps", type=int, default=1)
+    parser.add_argument("-x", "--resX", type=int, default=1024)
+    parser.add_argument("-y", "--resY", type=int, default=1024)
+    parser.add_argument("-i", "--camera_posX", type=float, default=1.5)
+    parser.add_argument("-j", "--camera_posY", type=float, default=0.5)
+    parser.add_argument("-k", "--camera_posZ", type=float, default=1.5)
+    parser.add_argument("-l", "--camera_lookatX", type=float, default=0.0)
+    parser.add_argument("-m", "--camera_lookatY", type=float, default=0.0)
+    parser.add_argument("-o", "--camera_lookatZ", type=float, default=0.5)
+    parser.add_argument("-v", "--camera_fov", type=float, default=45)
+    parser.add_argument("-f", "--mjcf", type=str, default="xml/franka_emika_panda/panda.xml")
+    parser.add_argument("-g", "--benchmark_result_file_path", type=str, default="benchmark.csv")
+    args = parser.parse_args()
+    benchmark_args = BenchmarkArgs(
+        rasterizer=args.rasterizer,
+        n_envs=args.n_envs,
+        n_steps=args.n_steps,
+        resX=args.resX,
+        resY=args.resY,
+        camera_posX=args.camera_posX,
+        camera_posY=args.camera_posY,
+        camera_posZ=args.camera_posZ,
+        camera_lookatX=args.camera_lookatX,
+        camera_lookatY=args.camera_lookatY,
+        camera_lookatZ=args.camera_lookatZ,
+        camera_fov=args.camera_fov,
+        mjcf=args.mjcf,
+        benchmark_result_file_path=args.benchmark_result_file_path,
+    )
+    print(f"Benchmark with args:")
+    print(f"  rasterizer: {benchmark_args.rasterizer}")
+    print(f"  n_envs: {benchmark_args.n_envs}")
+    print(f"  n_steps: {benchmark_args.n_steps}")
+    print(f"  resolution: {benchmark_args.resX}x{benchmark_args.resY}")
+    print(f"  camera_pos: ({benchmark_args.camera_posX}, {benchmark_args.camera_posY}, {benchmark_args.camera_posZ})")
+    print(f"  camera_lookat: ({benchmark_args.camera_lookatX}, {benchmark_args.camera_lookatY}, {benchmark_args.camera_lookatZ})")
+    print(f"  camera_fov: {benchmark_args.camera_fov}")
+    print(f"  mjcf: {benchmark_args.mjcf}")
+    print(f"  benchmark_result_file_path: {benchmark_args.benchmark_result_file_path}")
+    return benchmark_args
+
+def init_gs(benchmark_args):
+    ########################## init ##########################
+    try:
+        gs.init(backend=gs.gpu)
+    except Exception as e:
+        print(f"Failed to initialize GPU backend: {e}")
+        print("Falling back to CPU backend")
+        gs.init(backend=gs.cpu)
+    
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(benchmark_args.camera_posX, benchmark_args.camera_posY, benchmark_args.camera_posZ),
+            camera_lookat=(benchmark_args.camera_lookatX, benchmark_args.camera_lookatY, benchmark_args.camera_lookatZ),
+            camera_fov=benchmark_args.camera_fov,
+        ),
+        show_viewer=False,
+        rigid_options=gs.options.RigidOptions(
+            # constraint_solver=gs.constraint_solver.Newton,
+            ),
+        renderer = gs.options.renderers.BatchRenderer(
+            use_rasterizer=benchmark_args.rasterizer,
+            batch_render_res=(benchmark_args.resX, benchmark_args.resY),
+        )            
+    )
+
+    ########################## entities ##########################
+    #plane = scene.add_entity(
+    #    gs.morphs.Plane(),
+    #)
+    franka = scene.add_entity(
+        gs.morphs.MJCF(file=benchmark_args.mjcf),
+        visualize_contact=True,
+    )
+
+    ########################## cameras ##########################
+    cam_0 = scene.add_camera(
+        pos=(benchmark_args.camera_posX, benchmark_args.camera_posY, benchmark_args.camera_posZ),
+        lookat=(benchmark_args.camera_lookatX, benchmark_args.camera_lookatY, benchmark_args.camera_lookatZ),
+        fov=benchmark_args.camera_fov,
+    )
+    scene.add_light(
+        pos=[0.0, 0.0, 1.5],
+        dir=[1.0, 1.0, -2.0],
+        directional=1,
+        castshadow=1,
+        cutoff=45.0,
+        intensity=0.5
+    )
+    scene.add_light(
+        pos=[4, -4, 4],
+        dir=[-1, 1, -1],
+        directional=0,
+        castshadow=1,
+        cutoff=45.0,
+        intensity=1
+    )
+    ########################## build ##########################
+    n_envs = benchmark_args.n_envs
+    n_steps = benchmark_args.n_steps
+    scene.build(n_envs=n_envs)
+    return scene, n_envs, n_steps
+
+def run_benchmark(scene, n_envs, n_steps, benchmark_args):
+    try:
+        # warmup
+        scene.step()
+        rgb, depth = scene.batch_render()
+
+        # timer
+        from time import time
+        start_time = time()
+
+        for i in range(n_steps):
+            #scene.step()
+            rgb, depth = scene.batch_render()
+        
+        end_time = time()
+        time_taken = end_time - start_time
+        time_taken_per_env = time_taken / n_envs
+        fps = n_envs * n_steps / time_taken
+        fps_per_env = n_steps / time_taken
+
+        print(f'Time taken: {time_taken} seconds')
+        print(f'Time taken per env: {time_taken_per_env} seconds')
+        print(f'FPS: {fps}')
+        print(f'FPS per env: {fps_per_env}')
+
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(benchmark_args.benchmark_result_file_path), exist_ok=True)
+
+        # Append a line with all args and results in csv format
+        with open(benchmark_args.benchmark_result_file_path, 'a') as f:
+            f.write(f'succeeded,{benchmark_args.mjcf},{benchmark_args.rasterizer},{benchmark_args.n_envs},{benchmark_args.n_steps},{benchmark_args.resX},{benchmark_args.resY},{benchmark_args.camera_posX},{benchmark_args.camera_posY},{benchmark_args.camera_posZ},{benchmark_args.camera_lookatX},{benchmark_args.camera_lookatY},{benchmark_args.camera_lookatZ},{benchmark_args.camera_fov},{time_taken},{time_taken_per_env},{fps},{fps_per_env}\n')
+    except Exception as e:
+        print(f"Error during benchmark: {e}")
+        raise
+
+def main():
+    ######################## Parse arguments #######################
+    benchmark_args = parse_args()
+
+    ######################## Initialize scene #######################
+    scene, n_envs, n_steps = init_gs(benchmark_args)
+
+    ######################## Run benchmark #######################
+    run_benchmark(scene, n_envs, n_steps, benchmark_args)
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/perf_benchmark/benchmark_plotter.py
+++ b/examples/perf_benchmark/benchmark_plotter.py
@@ -1,0 +1,428 @@
+import glob
+import os
+import html
+import argparse
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.ticker import ScalarFormatter
+
+def generatePlotHtml(plots_dir):
+    #Generate an html page to display all the plots
+    
+    # Create HTML file
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Benchmark Results</title>
+        <style>
+            body { font-family: Arial, sans-serif; margin: 40px; }
+            .plot-container { margin-bottom: 40px; }
+            .section { margin-bottom: 60px; }
+            img { max-width: 100%; border: 1px solid #ddd; }
+            h1 { color: #333; }
+            h2 { color: #333; }
+            h3 { color: #666; margin-top: 30px; }
+        </style>
+    </head>
+    <body>
+        <h1>Benchmark Results</h1>
+    """
+
+    # Get all plot files
+    plot_files = glob.glob(f"{plots_dir}/*.png")
+    
+    # Separate regular plots from difference plots
+    regular_plots = [p for p in plot_files if not p.endswith('_difference.png') and not any(p.endswith(f'_difference_{ar.replace(":", "x")}.png') for ar in ["1:1", "4:3", "16:9"])]
+    aspect_ratio_plots = {
+        "1:1": [p for p in plot_files if p.endswith('_difference_1x1.png')],
+        "4:3": [p for p in plot_files if p.endswith('_difference_4x3.png')],
+        "16:9": [p for p in plot_files if p.endswith('_difference_16x9.png')]
+    }
+    
+    # Group regular plots by MJCF file
+    plot_groups = {}
+    for plot_file in regular_plots:
+        basename = os.path.basename(plot_file)
+        mjcf_name = basename.split('_')[0]
+        if mjcf_name not in plot_groups:
+            plot_groups[mjcf_name] = []
+        plot_groups[mjcf_name].append(plot_file)
+
+    # Sort plot groups by mjcf name and plot file name
+    plot_groups = sorted(plot_groups.items(), key=lambda x: (x[0], x[1][0]))
+
+    # Group aspect ratio plots by MJCF file
+    aspect_ratio_groups = {}
+    for aspect_ratio, plots in aspect_ratio_plots.items():
+        aspect_ratio_groups[aspect_ratio] = {}
+        for plot_file in plots:
+            basename = os.path.basename(plot_file)
+            mjcf_name = basename.split('_')[0]
+            if mjcf_name not in aspect_ratio_groups[aspect_ratio]:
+                aspect_ratio_groups[aspect_ratio][mjcf_name] = []
+            aspect_ratio_groups[aspect_ratio][mjcf_name].append(plot_file)
+        
+        # Sort each aspect ratio's plot groups
+        aspect_ratio_groups[aspect_ratio] = sorted(aspect_ratio_groups[aspect_ratio].items(), key=lambda x: (x[0], x[1][0]))
+
+    # Add regular plots section
+    html_content += "<div class='section'>\n"
+    html_content += "<h2>Performance Plots</h2>\n"
+    for mjcf_name, plots in plot_groups:
+        html_content += f"<div class='plot-container'>\n"
+        for plot in plots:
+            html_content += f"<h3>{html.escape(mjcf_name)} - {'Rasterizer' if 'rasterizer' in os.path.basename(plot) else 'Raytracer'}</h3>\n"
+            html_content += f"<img src='{html.escape(os.path.basename(plot))}' alt='{html.escape(os.path.basename(plot))}'/><br/>\n"
+        html_content += "</div>\n"
+    html_content += "</div>\n"
+
+    # Add aspect ratio difference plots sections
+    for aspect_ratio, mjcf_groups in aspect_ratio_groups.items():
+        if mjcf_groups:
+            html_content += "<div class='section'>\n"
+            html_content += f"<h2>Performance Difference Plots (Rasterizer / Raytracer) ({aspect_ratio} Resolutions Only)</h2>\n"
+            for mjcf_name, plots in mjcf_groups:
+                html_content += f"<div class='plot-container'>\n"
+                html_content += f"<h3>{html.escape(mjcf_name)}</h3>\n"
+                html_content += f"<img src='{html.escape(os.path.basename(plots[0]))}' alt='{html.escape(os.path.basename(plots[0]))}'/><br/>\n"
+                html_content += "</div>\n"
+            html_content += "</div>\n"
+
+    html_content += """
+    </body>
+    </html>
+    """
+
+    # Write HTML file
+    with open(f"{plots_dir}/index.html", 'w') as f:
+        f.write(html_content)
+
+def plot_batch_benchmark(data_file_path, width=20, height=15):
+    # Load the log file as csv
+    # For each mjcf, rasterizer (rasterizer or not(=raytracer)), generate a plot image and save it to a directory.
+    # The plot image has batch size on the x-axis and fps on the y-axis.
+    # Each resolution has a different color.
+    # The plot image has a legend for the resolution.
+    # The plot image has a title for the mjcf.
+    # The plot image has a x-axis label for the batch size.
+    # The plot image has a y-axis label for the fps.
+
+    # Read CSV file
+    df = pd.read_csv(data_file_path)
+
+    # Create plots directory if it doesn't exist
+    plots_dir = f"logs/benchmark/plots/{os.path.basename(data_file_path)}"
+    if not os.path.exists(plots_dir):
+        os.makedirs(plots_dir)
+    # Generate individual plots for each mjcf/rasterizer combination
+    generate_individual_plots(df, plots_dir, width, height)
+
+    # Generate difference plots for specific aspect ratios
+    for aspect_ratio in ["1:1", "4:3", "16:9"]:
+        generate_ratio_plots(df, plots_dir, width, height, aspect_ratio=aspect_ratio)
+
+    # Generate an html page to display all the plots
+    generatePlotHtml(plots_dir)
+
+def generate_individual_plots(df, plots_dir, width, height):
+    # Get unique combinations of mjcf and rasterizer
+    for mjcf in df['mjcf'].unique():
+        for rasterizer in df[df['mjcf'] == mjcf]['rasterizer'].unique():
+            # Filter data for this mjcf and rasterizer
+            data = df[(df['mjcf'] == mjcf) & (df['rasterizer'] == rasterizer)]
+            
+            # Create new figure
+            plt.figure(figsize=(width, height))
+            
+            # Plot each resolution with different color
+            # Sort by resX and resY before plotting
+            for res in sorted(data.groupby(['resX', 'resY']), key=lambda x: (x[0][0], x[0][1])):
+                resolution = res[0]
+                res_data = res[1]
+                plt.plot(res_data['n_envs'], res_data['fps'], 
+                        marker='o', label=f'{resolution[0]}x{resolution[1]}')
+                
+                # Add x/y value annotations near each point
+                for x, y in zip(res_data['n_envs'], res_data['fps']):
+                    plt.annotate(f'({x:.0f}, {y:.1f})', 
+                               (x, y),
+                               xytext=(5, 5),
+                               textcoords='offset points',
+                               fontsize=8)
+            
+            # Customize plot
+            plt.title(f'Performance for {os.path.basename(mjcf)}\n{"Rasterizer" if rasterizer else "Raytracer"}')
+            plt.xlabel('Batch Size')
+            plt.ylabel('FPS')
+            plt.grid(True)
+            plt.legend(title='Resolution')
+            plt.xscale('log')
+            plt.yscale('log')
+            
+            # Force both axes to use ScalarFormatter
+            # Get current axes
+            ax = plt.gca()
+            
+            # Set major formatter for both axes
+            ax.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+            ax.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+
+            # Disable scientific notation
+            ax.ticklabel_format(axis='both', style='plain')
+            
+            # Add more tick marks
+            ax.xaxis.set_major_locator(plt.LogLocator(base=2))
+            ax.yaxis.set_major_locator(plt.LogLocator(base=10))
+            
+            # Add minor tick marks
+            ax.xaxis.set_minor_locator(plt.LogLocator(base=2, subs=(.5,)))
+            ax.yaxis.set_minor_locator(plt.LogLocator(base=10, subs=(.5,)))
+            
+            # Save plot
+            rasterizer_str = "rasterizer" if rasterizer else "raytracer"
+            filename = f"{plots_dir}/{os.path.splitext(os.path.basename(mjcf))[0]}_{rasterizer_str}.png"
+            plt.savefig(filename)
+            plt.close()
+
+def generate_difference_plots(df, plots_dir, width, height, aspect_ratio=None):
+    # Filter by aspect ratio if specified
+    if aspect_ratio:
+        if aspect_ratio == "1:1":
+            df = df[df['resX'] == df['resY']]
+        elif aspect_ratio == "4:3":
+            df = df[df['resX'] * 3 == df['resY'] * 4]
+        elif aspect_ratio == "16:9":
+            df = df[df['resX'] * 9 == df['resY'] * 16]
+        else:
+            raise ValueError(f"Unsupported aspect ratio: {aspect_ratio}")
+
+    plt.clf()
+    plt.cla()
+
+    # Generate plots showing fps difference between rasterizer and raytracer
+    for mjcf in df['mjcf'].unique():
+        mjcf_data = df[df['mjcf'] == mjcf]
+        
+        # Get resolutions available for both rasterizer and raytracer
+        rasterizer_res = set(zip(mjcf_data[mjcf_data['rasterizer']]['resX'], 
+                                mjcf_data[mjcf_data['rasterizer']]['resY']))
+        raytracer_res = set(zip(mjcf_data[~mjcf_data['rasterizer']]['resX'],
+                               mjcf_data[~mjcf_data['rasterizer']]['resY']))
+        common_res = rasterizer_res.intersection(raytracer_res)
+        
+        plt.figure(figsize=(width, height))
+        
+        # Plot difference for each common resolution
+        max_abs_diff = 0  # Track maximum absolute difference for y-axis limits
+        min_abs_diff = 1e10
+        for resX, resY in sorted(common_res, key=lambda x: x[0] * x[1]):
+            rast_data = mjcf_data[(mjcf_data['rasterizer']) & 
+                                 (mjcf_data['resX'] == resX) & 
+                                 (mjcf_data['resY'] == resY)]
+            ray_data = mjcf_data[(~mjcf_data['rasterizer']) &
+                                (mjcf_data['resX'] == resX) &
+                                (mjcf_data['resY'] == resY)]
+            
+            # Match batch sizes and calculate difference
+            common_batch = set(rast_data['n_envs']).intersection(set(ray_data['n_envs']))
+            batch_sizes = sorted(list(common_batch))
+            
+            rast_fps = rast_data[rast_data['n_envs'].isin(batch_sizes)]['fps'].values
+            ray_fps = ray_data[ray_data['n_envs'].isin(batch_sizes)]['fps'].values
+            diff_fps = rast_fps - ray_fps
+            
+            # Update max absolute difference
+            max_abs_diff = max(max_abs_diff, diff_fps.max())
+            min_abs_diff = min(min_abs_diff, diff_fps.min())
+
+            plt.plot(batch_sizes, diff_fps, marker='o', label=f'{resX}x{resY}')
+            
+            # Add annotations
+            for x, y in zip(batch_sizes, diff_fps):
+                plt.annotate(f'({x:.0f}, {y:.1f})',
+                           (x, y),
+                           xytext=(5, 5),
+                           textcoords='offset points',
+                           fontsize=8)
+        
+        # Set title based on aspect ratio
+        subtitle1 = "FPS Difference (Rasterizer - Raytracer)"
+        if aspect_ratio:
+            subtitle2 = f"({aspect_ratio} Resolutions Only)"
+        else:
+            subtitle2 = ""
+        plt.title(f'{subtitle1}\n{os.path.basename(mjcf)} {subtitle2}')
+        plt.xlabel('Batch Size')
+        plt.ylabel(subtitle1)
+        plt.grid(True)
+        plt.legend(title='Resolution')
+        plt.xscale('log')
+        plt.yscale('symlog', linthresh=1.0)  # Use symlog with linear threshold of 1.0
+        
+        # Format axes
+        ax = plt.gca()
+            
+        # Set major formatter for both axes
+        ax.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+        ax.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+
+        # Disable scientific notation
+        ax.ticklabel_format(axis='both', style='plain')
+        
+        # Add more tick marks
+        ax.xaxis.set_major_locator(plt.LogLocator(base=2))
+        ax.yaxis.set_major_locator(plt.LogLocator(base=10))
+        
+        # Add minor tick marks
+        ax.xaxis.set_minor_locator(plt.LogLocator(base=2, subs=(.5,)))
+        ax.yaxis.set_minor_locator(plt.LogLocator(base=10, subs=(.5,)))
+            
+        # Set y-axis limits symmetrically
+        ax.set_ylim(0, max_abs_diff*1.1)  # Add 10% padding
+        
+        # Add horizontal line at y=0 to show crossover point
+        plt.axhline(y=1, color='k', linestyle='--', alpha=0.3)
+        
+        # Save plot with aspect ratio in filename if specified
+        if aspect_ratio:
+            filename = f"{plots_dir}/{os.path.splitext(os.path.basename(mjcf))[0]}_difference_{aspect_ratio.replace(':', 'x')}.png"
+        else:
+            filename = f"{plots_dir}/{os.path.splitext(os.path.basename(mjcf))[0]}_difference.png"
+        plt.savefig(filename)
+        plt.close()
+
+def generate_ratio_plots(df, plots_dir, width, height, aspect_ratio=None):
+    # Filter by aspect ratio if specified
+    if aspect_ratio:
+        if aspect_ratio == "1:1":
+            df = df[df['resX'] == df['resY']]
+        elif aspect_ratio == "4:3":
+            df = df[df['resX'] * 3 == df['resY'] * 4]
+        elif aspect_ratio == "16:9":
+            df = df[df['resX'] * 9 == df['resY'] * 16]
+        else:
+            raise ValueError(f"Unsupported aspect ratio: {aspect_ratio}")
+
+    plt.clf()
+    plt.cla()
+
+    # Generate plots showing fps difference between rasterizer and raytracer
+    for mjcf in df['mjcf'].unique():
+        mjcf_data = df[df['mjcf'] == mjcf]
+        
+        # Get resolutions available for both rasterizer and raytracer
+        rasterizer_res = set(zip(mjcf_data[mjcf_data['rasterizer']]['resX'], 
+                                mjcf_data[mjcf_data['rasterizer']]['resY']))
+        raytracer_res = set(zip(mjcf_data[~mjcf_data['rasterizer']]['resX'],
+                               mjcf_data[~mjcf_data['rasterizer']]['resY']))
+        common_res = rasterizer_res.intersection(raytracer_res)
+        
+        plt.figure(figsize=(width, height))
+        
+        # Plot difference for each common resolution
+        max_abs_diff = 0  # Track maximum absolute difference for y-axis limits
+        min_abs_diff = 1e10
+        for resX, resY in sorted(common_res, key=lambda x: x[0] * x[1]):
+            rast_data = mjcf_data[(mjcf_data['rasterizer']) & 
+                                 (mjcf_data['resX'] == resX) & 
+                                 (mjcf_data['resY'] == resY)]
+            ray_data = mjcf_data[(~mjcf_data['rasterizer']) &
+                                (mjcf_data['resX'] == resX) &
+                                (mjcf_data['resY'] == resY)]
+            
+            # Match batch sizes and calculate difference
+            common_batch = set(rast_data['n_envs']).intersection(set(ray_data['n_envs']))
+            batch_sizes = sorted(list(common_batch))
+            
+            rast_fps = rast_data[rast_data['n_envs'].isin(batch_sizes)]['fps'].values
+            ray_fps = ray_data[ray_data['n_envs'].isin(batch_sizes)]['fps'].values
+            diff_fps = rast_fps / ray_fps
+            
+            # Update max absolute difference
+            max_abs_diff = max(max_abs_diff, diff_fps.max())
+            min_abs_diff = min(min_abs_diff, diff_fps.min())
+
+            plt.plot(batch_sizes, diff_fps, marker='o', label=f'{resX}x{resY}')
+            
+            # Add annotations
+            for x, y in zip(batch_sizes, diff_fps):
+                plt.annotate(f'({x:.0f}, {y:.1f})',
+                           (x, y),
+                           xytext=(5, 5),
+                           textcoords='offset points',
+                           fontsize=8)
+        
+        # Set title based on aspect ratio
+        subtitle1 = "FPS Difference (Rasterizer / Raytracer)"
+        if aspect_ratio:
+            subtitle2 = f"({aspect_ratio} Resolutions Only)"
+        else:
+            subtitle2 = ""
+        plt.title(f'{subtitle1}\n{os.path.basename(mjcf)} {subtitle2}')
+        plt.xlabel('Batch Size')
+        plt.ylabel(subtitle1)
+        plt.grid(True)
+        plt.legend(title='Resolution')
+        plt.xscale('log')
+        plt.yscale('log')  # Use log scale with smaller base for better resolution near 1.0
+        
+        # Format axes
+        ax = plt.gca()
+            
+        # Set major formatter for both axes
+        ax.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+        ax.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+
+        # Disable scientific notation
+        ax.ticklabel_format(axis='both', style='plain')
+        
+        # Add more tick marks
+        ax.xaxis.set_major_locator(plt.LogLocator(base=2))
+        ax.yaxis.set_major_locator(plt.LogLocator(base=10))
+        
+        # Add minor tick marks
+        ax.xaxis.set_minor_locator(plt.LogLocator(base=2, subs=(.5,)))
+        ax.yaxis.set_minor_locator(plt.LogLocator(base=10, subs=(.5,)))
+
+        # Set y-axis limits to ensure all points are visible
+        #ax.set_ylim(min_abs_diff * 0.9, max_abs_diff * 1.1)  # Add 10% padding
+        ax.autoscale(enable=True, axis='y')
+        
+        # Add horizontal line at y=1 to show crossover point
+        plt.axhline(y=1, color='k', linestyle='--', alpha=0.3)
+        
+        # Save plot with aspect ratio in filename if specified
+        if aspect_ratio:
+            filename = f"{plots_dir}/{os.path.splitext(os.path.basename(mjcf))[0]}_difference_{aspect_ratio.replace(':', 'x')}.png"
+        else:
+            filename = f"{plots_dir}/{os.path.splitext(os.path.basename(mjcf))[0]}_difference.png"
+        plt.savefig(filename)
+        plt.close()
+
+def main():
+    import sys
+    import os
+    print("Script arguments:", sys.argv)  # Debug print
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--data_file_path", type=str, default="logs/benchmark/batch_benchmark_20250524_180908.csv",
+                       help="Path to the benchmark data CSV file")
+    parser.add_argument("-w", "--width", type=int, default=20,
+                       help="Width of the plot in inches")
+    parser.add_argument("-y", "--height", type=int, default=15,
+                       help="Height of the plot in inches")
+    
+    # If no arguments provided, try to get from environment variables
+    if len(sys.argv) == 1:
+        data_file = os.environ.get('BENCHMARK_DATA_FILE')
+        if data_file:
+            sys.argv.extend(['-d', data_file])
+    
+    args = parser.parse_args()
+    print("Parsed arguments:", args)  # Debug print
+    plot_batch_benchmark(args.data_file_path, args.width, args.height)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Update performance  benchmark scripts

Run `batch_benchmark.py` to run the batch benchmark with minimal combination of resolutions and batch size.
Run `batch_benchmark.py -f` to run the full list, which may take up to 48 hours to finish.
Run `batch_benchmark.py -c [csv_file_path]` to continue from the last benchmark run, in case a benchmark run crashed or was manually terminated.